### PR TITLE
Add tax summary and detail report for purchases and sales

### DIFF
--- a/l10n_cr_custom_18_v2/report/report_sales_purchase.xml
+++ b/l10n_cr_custom_18_v2/report/report_sales_purchase.xml
@@ -11,4 +11,16 @@
         binding_model_id="account.model_account_move"
         binding_type="report"
     />
+    <report
+        id="action_report_sales_purchase_detail"
+        model="account.move"
+        string="Reporte de Compras y Ventas (Detallado)"
+        report_type="qweb-pdf"
+        name="l10n_cr_custom_18_v2.report_sales_purchase"
+        file="l10n_cr_custom_18_v2.report_sales_purchase"
+        print_report_name="'Reporte_Compras_Ventas_Detallado_' + (object.name or '')"
+        binding_model_id="account.model_account_move"
+        binding_type="report"
+        context="{'report_detail': True}"
+    />
 </odoo>

--- a/l10n_cr_custom_18_v2/report/report_sales_purchase_templates.xml
+++ b/l10n_cr_custom_18_v2/report/report_sales_purchase_templates.xml
@@ -8,44 +8,36 @@
                     <p>
                         <span t-esc="company.name"/>
                     </p>
-                    <t t-if="sale_moves">
+                    <t t-if="sale_summary">
                         <h3>Ventas</h3>
                         <table class="table table-sm o_main_table">
                             <thead>
                                 <tr>
-                                    <th>Documento</th>
-                                    <th>Cliente</th>
-                                    <th>Fecha</th>
+                                    <th>Impuesto</th>
                                     <th class="text-right">Base</th>
-                                    <th class="text-right">Impuestos</th>
+                                    <th class="text-right">Impuesto</th>
                                     <th class="text-right">Total</th>
                                 </tr>
                             </thead>
                             <tbody>
-                                <tr t-foreach="sale_moves" t-as="move">
+                                <tr t-foreach="sale_summary" t-as="line">
                                     <td>
-                                        <span t-esc="move.name or move.ref"/>
-                                    </td>
-                                    <td>
-                                        <span t-esc="move.partner_id.display_name"/>
-                                    </td>
-                                    <td>
-                                        <span t-esc="format_date(move.invoice_date or move.date)"/>
+                                        <span t-esc="line['tax_name']"/>
                                     </td>
                                     <td class="text-right">
-                                        <span t-esc="formatLang(move.amount_untaxed, currency_obj=move.currency_id)"/>
+                                        <span t-esc="formatLang(line['base'], currency_obj=company_currency)"/>
                                     </td>
                                     <td class="text-right">
-                                        <span t-esc="formatLang(move.amount_tax, currency_obj=move.currency_id)"/>
+                                        <span t-esc="formatLang(line['tax'], currency_obj=company_currency)"/>
                                     </td>
                                     <td class="text-right">
-                                        <span t-esc="formatLang(move.amount_total, currency_obj=move.currency_id)"/>
+                                        <span t-esc="formatLang(line['total'], currency_obj=company_currency)"/>
                                     </td>
                                 </tr>
                             </tbody>
                             <tfoot>
                                 <tr>
-                                    <th colspan="3" class="text-right">Totales</th>
+                                    <th class="text-right">Totales</th>
                                     <th class="text-right">
                                         <span t-esc="formatLang(sale_totals['base'], currency_obj=company_currency)"/>
                                     </th>
@@ -59,44 +51,36 @@
                             </tfoot>
                         </table>
                     </t>
-                    <t t-if="purchase_moves">
+                    <t t-if="purchase_summary">
                         <h3>Compras</h3>
                         <table class="table table-sm o_main_table">
                             <thead>
                                 <tr>
-                                    <th>Documento</th>
-                                    <th>Proveedor</th>
-                                    <th>Fecha</th>
+                                    <th>Impuesto</th>
                                     <th class="text-right">Base</th>
-                                    <th class="text-right">Impuestos</th>
+                                    <th class="text-right">Impuesto</th>
                                     <th class="text-right">Total</th>
                                 </tr>
                             </thead>
                             <tbody>
-                                <tr t-foreach="purchase_moves" t-as="move">
+                                <tr t-foreach="purchase_summary" t-as="line">
                                     <td>
-                                        <span t-esc="move.name or move.ref"/>
-                                    </td>
-                                    <td>
-                                        <span t-esc="move.partner_id.display_name"/>
-                                    </td>
-                                    <td>
-                                        <span t-esc="format_date(move.invoice_date or move.date)"/>
+                                        <span t-esc="line['tax_name']"/>
                                     </td>
                                     <td class="text-right">
-                                        <span t-esc="formatLang(move.amount_untaxed, currency_obj=move.currency_id)"/>
+                                        <span t-esc="formatLang(line['base'], currency_obj=company_currency)"/>
                                     </td>
                                     <td class="text-right">
-                                        <span t-esc="formatLang(move.amount_tax, currency_obj=move.currency_id)"/>
+                                        <span t-esc="formatLang(line['tax'], currency_obj=company_currency)"/>
                                     </td>
                                     <td class="text-right">
-                                        <span t-esc="formatLang(move.amount_total, currency_obj=move.currency_id)"/>
+                                        <span t-esc="formatLang(line['total'], currency_obj=company_currency)"/>
                                     </td>
                                 </tr>
                             </tbody>
                             <tfoot>
                                 <tr>
-                                    <th colspan="3" class="text-right">Totales</th>
+                                    <th class="text-right">Totales</th>
                                     <th class="text-right">
                                         <span t-esc="formatLang(purchase_totals['base'], currency_obj=company_currency)"/>
                                     </th>
@@ -110,8 +94,87 @@
                             </tfoot>
                         </table>
                     </t>
-                    <t t-if="not sale_moves and not purchase_moves">
-                        <p>No se encontraron movimientos de ventas o compras para los registros seleccionados.</p>
+                    <t t-if="not sale_summary and not purchase_summary">
+                        <p>No se encontraron impuestos generados para los registros seleccionados.</p>
+                    </t>
+                    <t t-if="show_details and (sale_details or purchase_details)">
+                        <div class="mt16">
+                            <h3>Detalle por documento</h3>
+                        </div>
+                        <t t-if="sale_details">
+                            <h4>Ventas</h4>
+                            <table class="table table-sm o_main_table">
+                                <thead>
+                                    <tr>
+                                        <th>Documento</th>
+                                        <th>Fecha</th>
+                                        <th>Impuesto</th>
+                                        <th class="text-right">Base</th>
+                                        <th class="text-right">Impuesto</th>
+                                        <th class="text-right">Total</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr t-foreach="sale_details" t-as="detail">
+                                        <td>
+                                            <span t-esc="detail['document']"/>
+                                        </td>
+                                        <td>
+                                            <span t-esc="format_date(detail['date'])"/>
+                                        </td>
+                                        <td>
+                                            <span t-esc="detail['tax_name']"/>
+                                        </td>
+                                        <td class="text-right">
+                                            <span t-esc="formatLang(detail['base'], currency_obj=company_currency)"/>
+                                        </td>
+                                        <td class="text-right">
+                                            <span t-esc="formatLang(detail['tax'], currency_obj=company_currency)"/>
+                                        </td>
+                                        <td class="text-right">
+                                            <span t-esc="formatLang(detail['total'], currency_obj=company_currency)"/>
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </t>
+                        <t t-if="purchase_details">
+                            <h4>Compras</h4>
+                            <table class="table table-sm o_main_table">
+                                <thead>
+                                    <tr>
+                                        <th>Documento</th>
+                                        <th>Fecha</th>
+                                        <th>Impuesto</th>
+                                        <th class="text-right">Base</th>
+                                        <th class="text-right">Impuesto</th>
+                                        <th class="text-right">Total</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr t-foreach="purchase_details" t-as="detail">
+                                        <td>
+                                            <span t-esc="detail['document']"/>
+                                        </td>
+                                        <td>
+                                            <span t-esc="format_date(detail['date'])"/>
+                                        </td>
+                                        <td>
+                                            <span t-esc="detail['tax_name']"/>
+                                        </td>
+                                        <td class="text-right">
+                                            <span t-esc="formatLang(detail['base'], currency_obj=company_currency)"/>
+                                        </td>
+                                        <td class="text-right">
+                                            <span t-esc="formatLang(detail['tax'], currency_obj=company_currency)"/>
+                                        </td>
+                                        <td class="text-right">
+                                            <span t-esc="formatLang(detail['total'], currency_obj=company_currency)"/>
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </t>
                     </t>
                     <div class="mt16">
                         <strong>Total general</strong>

--- a/l10n_cr_custom_18_v2/reports/report_sales_purchase.py
+++ b/l10n_cr_custom_18_v2/reports/report_sales_purchase.py
@@ -1,4 +1,6 @@
-from odoo import models
+from collections import defaultdict
+
+from odoo import fields, models
 
 
 class ReportSalesPurchase(models.AbstractModel):
@@ -21,15 +23,70 @@ class ReportSalesPurchase(models.AbstractModel):
             relevant_moves.filtered(lambda m: m.move_type in ('in_invoice', 'in_refund'))
         )
 
-        def _totals(recordset):
-            return {
-                'base': sum(recordset.mapped('amount_untaxed')),
-                'tax': sum(recordset.mapped('amount_tax')),
-                'total': sum(recordset.mapped('amount_total')),
-            }
-
         company = self.env.company
         company_currency = company.currency_id
+
+        today = fields.Date.context_today(self)
+
+        def _tax_report_values(moveset):
+            summary = defaultdict(lambda: {
+                'tax_id': False,
+                'tax_name': '',
+                'base': 0.0,
+                'tax': 0.0,
+                'total': 0.0,
+            })
+            details = []
+
+            for move in moveset:
+                tax_lines = move.line_ids.filtered('tax_line_id')
+                for line in tax_lines:
+                    tax = line.tax_line_id
+                    base_amount = company_currency.round(line.tax_base_amount or 0.0)
+                    tax_amount = company_currency.round(line.balance or 0.0)
+                    total_amount = base_amount + tax_amount
+
+                    entry = summary[tax.id]
+                    entry['tax_id'] = tax.id
+                    entry['tax_name'] = tax.display_name or tax.name
+                    entry['base'] += base_amount
+                    entry['tax'] += tax_amount
+                    entry['total'] += total_amount
+
+                    details.append({
+                        'document': move.name or move.ref or '',
+                        'date': fields.Date.to_date(move.invoice_date or move.date),
+                        'tax_name': entry['tax_name'],
+                        'base': base_amount,
+                        'tax': tax_amount,
+                        'total': total_amount,
+                    })
+
+            summary_list = sorted(summary.values(), key=lambda item: item['tax_name'] or '')
+            details.sort(key=lambda item: (item['date'] or today, item['document']))
+
+            totals = {
+                'base': sum(item['base'] for item in summary_list),
+                'tax': sum(item['tax'] for item in summary_list),
+            }
+            totals['total'] = totals['base'] + totals['tax']
+
+            return {
+                'summary': summary_list,
+                'details': details,
+                'totals': totals,
+            }
+
+        sale_data = _tax_report_values(sale_moves)
+        purchase_data = _tax_report_values(purchase_moves)
+
+        grand_totals = {
+            'base': sale_data['totals']['base'] + purchase_data['totals']['base'],
+            'tax': sale_data['totals']['tax'] + purchase_data['totals']['tax'],
+        }
+        grand_totals['total'] = grand_totals['base'] + grand_totals['tax']
+
+        show_details = bool(self.env.context.get('report_detail') or (data or {}).get('report_detail'))
 
         return {
             'doc_ids': relevant_moves.ids,
@@ -37,9 +94,14 @@ class ReportSalesPurchase(models.AbstractModel):
             'docs': relevant_moves,
             'sale_moves': sale_moves,
             'purchase_moves': purchase_moves,
-            'sale_totals': _totals(sale_moves),
-            'purchase_totals': _totals(purchase_moves),
-            'grand_totals': _totals(relevant_moves),
+            'sale_summary': sale_data['summary'],
+            'purchase_summary': purchase_data['summary'],
+            'sale_totals': sale_data['totals'],
+            'purchase_totals': purchase_data['totals'],
+            'sale_details': sale_data['details'],
+            'purchase_details': purchase_data['details'],
+            'grand_totals': grand_totals,
+            'show_details': show_details,
             'company': company,
             'company_currency': company_currency,
         }


### PR DESCRIPTION
## Summary
- aggregate purchase and sales taxes by tax item in the report backend and expose optional detail data
- redesign the PDF template to show tax-based summaries with section subtotals and optional document-level detail tables
- add a second report action to print the detailed version of the purchases and sales tax report

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d5af00d8dc832684dc6384d7bee6e9