### PR TITLE
Fix chart template return value

### DIFF
--- a/l10n_cr_custom_19_v1/models/template_cr.py
+++ b/l10n_cr_custom_19_v1/models/template_cr.py
@@ -21,7 +21,7 @@ class L10nCRTemplate(models.AbstractModel):
             'default_sale_journal_id': 'cr_custom_sale_journal',
             'default_purchase_journal_id': 'cr_custom_purchase_journal',
 
-        },
+        }
 
     @template('cr_custom', 'account.journal')
     def _get_cr_custom_account_journals(self):


### PR DESCRIPTION
## Summary
- remove trailing comma from Costa Rica chart template data to return a dict instead of a tuple

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5d84a87a4832682526961bf75ce9a