### PR TITLE
Add chart template record for Costa Rica localization

### DIFF
--- a/l10n_cr_custom_19_v1/__manifest__.py
+++ b/l10n_cr_custom_19_v1/__manifest__.py
@@ -16,6 +16,7 @@
         "l10n_latam_invoice_document",
     ],
     "data": [
+        "data/account_chart_template.xml",
         "data/account_tax_tags.xml",
         "report/report_sales_purchase.xml",
         "report/report_sales_purchase_templates.xml",

--- a/l10n_cr_custom_19_v1/data/account_chart_template.xml
+++ b/l10n_cr_custom_19_v1/data/account_chart_template.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="cr_custom" model="account.chart.template">
+            <field name="name">Costa Rica - Custom</field>
+            <field name="visible" eval="True"/>
+            <field name="complete_tax_set" eval="True"/>
+            <field name="code_digits">7</field>
+            <field name="country_id" ref="base.cr"/>
+        </record>
+    </data>
+</odoo>

--- a/l10n_cr_custom_19_v1/docs/gap_analysis.md
+++ b/l10n_cr_custom_19_v1/docs/gap_analysis.md
@@ -5,7 +5,7 @@ This note summarizes the key elements that prevent the custom package from behav
 ## Manifest dependencies and data files
 
 * The module currently depends only on `account`, so core localizations such as `l10n_latam_base`, `l10n_latam_invoice_document`, or reporting helpers are never installed. The official module requires several of these add-ons before the chart template is usable. 【F:l10n_cr_custom_19_v1/__manifest__.py†L3-L22】
-* Only CSV templates and a couple of report/view definitions are loaded. There are no XML records to expose the chart template, taxes, or fiscal positions to the chart installation wizard, so the data never becomes available even though the CSV files exist in `data/template`. 【F:l10n_cr_custom_19_v1/__manifest__.py†L13-L21】
+* Only CSV templates and a couple of report/view definitions are loaded. There are no XML records to expose the chart template, taxes, or fiscal positions to the chart installation wizard, so the data never becomes available even though the CSV files exist in `data/template`. ✅ Se añadió `data/account_chart_template.xml` para crear el registro base del plan contable y hacerlo visible en el asistente. 【F:l10n_cr_custom_19_v1/__manifest__.py†L13-L21】【F:l10n_cr_custom_19_v1/data/account_chart_template.xml†L1-L12】
 
 ## Chart template implementation
 


### PR DESCRIPTION
## Summary
- register the Costa Rican chart template through a new XML data file so it becomes visible in the localization wizard
- document the gap analysis to note the new template record that exposes the chart to users

## Testing
- python -m compileall models

------
https://chatgpt.com/codex/tasks/task_e_68d64b8b6d808326bd6526dbca8af761