### PR TITLE
Add l10n_latam chart template record for Costa Rica custom localization

### DIFF
--- a/l10n_cr_custom_19_v1/__manifest__.py
+++ b/l10n_cr_custom_19_v1/__manifest__.py
@@ -17,6 +17,7 @@
     ],
     "data": [
         "data/account_chart_template.xml",
+        "data/l10n_latam_chart_template.xml",
         "data/account_tax_tags.xml",
         "report/report_sales_purchase.xml",
         "report/report_sales_purchase_templates.xml",

--- a/l10n_cr_custom_19_v1/data/l10n_latam_chart_template.xml
+++ b/l10n_cr_custom_19_v1/data/l10n_latam_chart_template.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="l10n_latam_chart_template_cr_custom" model="l10n_latam.chart.template">
+            <field name="name">Costa Rica - Custom</field>
+            <field name="chart_template_id" ref="l10n_cr_custom_19_v1.cr_custom"/>
+            <field name="country_id" ref="base.cr"/>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
## Summary
- add a LatAm chart template record that links the Costa Rica custom chart to the LatAm wrapper
- load the new record by including it in the module manifest data files

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d65245b6608326882014614004a361